### PR TITLE
fix tests on 1.5

### DIFF
--- a/src/FIGlet.jl
+++ b/src/FIGlet.jl
@@ -222,7 +222,7 @@ function readfont(io)
         end
     end
 
-    while bytesavailable(io) > 1
+    while !eof(io)
         s = readline(io)
         strip(s) == "" && continue
         s = split(s)[1]


### PR DESCRIPTION
I think this was sensitive to buffer sizes in the previous version. Tests failed on 1.5 with 

```
FIGlet.jl: Test Failed at /home/pkgeval/.julia/packages/FIGlet/My7b4/test/runtests.jl:29
  Expression: String(take!(iob)) == "FIGletFont(n=7098)"
   Evaluated: "FIGletFont(n=2469)" == "FIGletFont(n=7098)"
```